### PR TITLE
Optimise last function on tree nodes

### DIFF
--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -668,8 +668,13 @@ impl<const B: usize> OpTreeNode<B> {
     }
 
     pub fn last(&self) -> &Op {
-        // node is never empty so this is safe
-        self.get(self.len() - 1).unwrap()
+        if self.is_leaf() {
+            // node is never empty so this is safe
+            self.elements.last().unwrap()
+        } else {
+            // not a leaf so must have at least one child
+            self.children.last().unwrap().last()
+        }
     }
 
     pub fn get(&self, index: usize) -> Option<&Op> {


### PR DESCRIPTION
This is very hot in the trace so makes it considerably faster, ~400ms better on my machine.